### PR TITLE
Add option to disable copy page button

### DIFF
--- a/pages/docs/10_get_started.md
+++ b/pages/docs/10_get_started.md
@@ -73,6 +73,7 @@ theme:
   name: shadcn
   show_title: true # show the title in the top bar
   show_stargazers: true # show the stargazers in the top bar
+  show_copy_button: true # show copy button along with the previous and next buttons
   pygments_style: # default styles 
         light: shadcn-light
         dark: github-dark
@@ -90,10 +91,13 @@ theme:
 
 If `false`, only the icon will be visible in the top bar (left-side). Default to `true`.
 
-
 ### `show_stargazers: bool`
 
 If `false`, hides the GitHub stargazers besides the repo icon in the top bar (right side). Default to `true`.
+
+### `show_copy_button: bool`
+
+If `false`, hides the copy button besides the previous and next buttons. Default to `true`.
 
 ### `pygments_style: str | dict`
 

--- a/shadcn/mkdocs_theme.yml
+++ b/shadcn/mkdocs_theme.yml
@@ -1,5 +1,6 @@
 icon: null
 show_title: true
+show_copy_button: true
 show_stargazers: true
 pygments_style:
   light: shadcn-light

--- a/shadcn/templates/copy_button.html
+++ b/shadcn/templates/copy_button.html
@@ -1,5 +1,5 @@
 <button
-    onclick="fetch(`{{ raw_markdown_url | url }}`).then((r) => r.blob()).then((blob) => navigator.clipboard.write([new ClipboardItem({ 'text/plain': blob })]))"
+    onclick="fetch(`{{ raw_markdown_url | url }}`).then((r) => r.text()).then((text) => navigator.clipboard.write([new ClipboardItem({ 'text/plain': text })]))"
     data-slot="button" class="secondary cursor-pointer">
     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
         stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="tabler-icon tabler-icon-copy ">

--- a/shadcn/templates/page.html
+++ b/shadcn/templates/page.html
@@ -7,7 +7,9 @@
         </h1>
 
         <div class="flex items-center gap-2 pt-1.5">
+          {% if config.theme.show_copy_button %}
           {% include "templates/copy_button.html" %}
+          {% endif %}
           {% if page.previous_page %}
           <a data-slot="button" id="previous-button"
             class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg:not([class*='size-'])]:size-4 shrink-0 [&amp;_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-secondary text-secondary-foreground hover:bg-secondary/80 extend-touch-target size-8 shadow-none md:size-7"


### PR DESCRIPTION
Hi,

I can't find the option to do this currently.

The main reason I added this is in my fork is because I am getting an error with the button on Brave browser as reported in #91, and also simply because my documentation site doesn't need it in particular.

If you think it's worth adding. It would be great to see this in the next version :)

If I missed anything, feel free to let me know.