### PR TITLE
Icon/Favicon handling improvements

### DIFF
--- a/shadcn/filters.py
+++ b/shadcn/filters.py
@@ -104,15 +104,14 @@ def is_http_url(path: str) -> bool:
         return False
     return True
 
-def read_svg(path: str, config: MkDocsConfig) -> str:
-    """Read raw SVG content from a file, resolved from docs_dir"""
-    p: Path = Path(config.docs_dir) / Path(path)
+def read_file(path: str, config: MkDocsConfig) -> str:
+    """Read raw text content from a file, resolved from docs_dir"""
+    p: Path = Path(config.docs_dir) / path
     try:
         return p.read_text(encoding="utf-8")
     except OSError as err:
-        logger.error(f"failed to read svg file: {err} ({p})")
-        return "<svg></svg>"
-
+        logger.error(f"failed to read file: {err} ({p})")
+        return ""
 
 def is_svg(path: str) -> bool:
     """Check if a path points to an SVG file, based on extension"""

--- a/shadcn/filters.py
+++ b/shadcn/filters.py
@@ -103,3 +103,17 @@ def is_http_url(path: str) -> bool:
     if parsed.scheme not in ("http", "https", "data"):
         return False
     return True
+
+def read_svg(path: str, config: MkDocsConfig) -> str:
+    """Read raw SVG content from a file, resolved from docs_dir"""
+    p: Path = Path(config.docs_dir) / Path(path)
+    try:
+        return p.read_text(encoding="utf-8")
+    except OSError as err:
+        logger.error(f"failed to read svg file: {err} ({p})")
+        return "<svg></svg>"
+
+
+def is_svg(path: str) -> bool:
+    """Check if a path points to an SVG file, based on extension"""
+    return Path(path).suffix.lower() == ".svg"

--- a/shadcn/main.html
+++ b/shadcn/main.html
@@ -20,6 +20,8 @@
 
     {%- if config.theme.favicon %}
     <link href="{{ config.theme.favicon | url }}" rel="icon" />
+    {%- elif config.theme.icon %}
+    <link href="{{ config.theme.icon | url }}" rel="icon" />
     {%- else %}
     <link href="{{ 'img/favicon.ico' | url }}" rel="icon" />
     {%- endif %}

--- a/shadcn/plugins/search.py
+++ b/shadcn/plugins/search.py
@@ -13,7 +13,9 @@ from shadcn.filters import (
     first_page,
     iconify,
     is_http_url,
+    is_svg,
     parse_author,
+    read_svg,
     setattribute,
 )
 from shadcn.plugins.mixins.dev import DevServerMixin
@@ -61,6 +63,8 @@ class SearchPlugin(
         env.filters["first_page"] = first_page
         env.filters["file_exists"] = partial(file_exists, config=config)
         env.filters["is_http_url"] = is_http_url
+        env.filters["read_svg"] = partial(read_svg, config=config)
+        env.filters["is_svg"] = is_svg
         return super().on_env(env, config=config, files=files)
 
     def on_page_markdown(

--- a/shadcn/plugins/search.py
+++ b/shadcn/plugins/search.py
@@ -15,7 +15,7 @@ from shadcn.filters import (
     is_http_url,
     is_svg,
     parse_author,
-    read_svg,
+    read_file,
     setattribute,
 )
 from shadcn.plugins.mixins.dev import DevServerMixin
@@ -63,7 +63,7 @@ class SearchPlugin(
         env.filters["first_page"] = first_page
         env.filters["file_exists"] = partial(file_exists, config=config)
         env.filters["is_http_url"] = is_http_url
-        env.filters["read_svg"] = partial(read_svg, config=config)
+        env.filters["read_file"] = partial(read_file, config=config)
         env.filters["is_svg"] = is_svg
         return super().on_env(env, config=config, files=files)
 

--- a/shadcn/templates/icon.html
+++ b/shadcn/templates/icon.html
@@ -1,6 +1,10 @@
 {% if config.theme.icon %}
 {% if (config.theme.icon | file_exists) or (config.theme.icon | is_http_url) %}
+{% if (config.theme.icon | is_svg) and not (config.theme.icon | is_http_url) %}
+{{ config.theme.icon | read_svg | safe }}
+{% else %}
 <img class="size-5" src="{{ config.theme.icon | url }}" alt="icon">
+{% endif %}
 {% else %}
 {{ config.theme.icon | iconify }}
 {% endif %}

--- a/shadcn/templates/icon.html
+++ b/shadcn/templates/icon.html
@@ -1,7 +1,7 @@
 {% if config.theme.icon %}
 {% if (config.theme.icon | file_exists) or (config.theme.icon | is_http_url) %}
 {% if (config.theme.icon | is_svg) and not (config.theme.icon | is_http_url) %}
-{{ config.theme.icon | read_svg | safe }}
+{{ config.theme.icon | read_file | safe }}
 {% else %}
 <img class="size-5" src="{{ config.theme.icon | url }}" alt="icon">
 {% endif %}


### PR DESCRIPTION
Hi,

I have some changes to icon handling that you might find useful:

1. This uses the theme icon as the favicon if it is provided but a custom favicon isn't. Previously, it was always using default favicon, even when a theme icon is provided. So I had to provide both theme favicon and icon with the same file path.
2. Another thing I found useful is being able to inject the icon if it's an SVG, taking advantage of the currentColor and works as a template which the default icon seem to do.